### PR TITLE
Add nvim-cmp for completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a personal Neovim setup focused on writing Markdown and
 - Treesitter support for Markdown and Vimwiki
 - Git integration with gitsigns and vim-fugitive
 - LSP management via mason and mason-lspconfig
+- Auto completion powered by nvim-cmp
 - Formatting and linting through null-ls
 - Render Markdown preview in the terminal
 

--- a/lua/spreadneck/plugins/cmp.lua
+++ b/lua/spreadneck/plugins/cmp.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    "hrsh7th/nvim-cmp",
+    dependencies = {
+      "hrsh7th/cmp-buffer",
+      "hrsh7th/cmp-path",
+      "hrsh7th/cmp-nvim-lsp",
+    },
+    config = function()
+      local cmp = require "cmp"
+      cmp.setup {
+        mapping = cmp.mapping.preset.insert {
+          ["<Tab>"] = cmp.mapping.confirm { select = true },
+          ["<C-Space>"] = cmp.mapping.complete {},
+          ["<C-n>"] = cmp.mapping.select_next_item(),
+          ["<C-p>"] = cmp.mapping.select_prev_item(),
+        },
+        sources = {
+          { name = "nvim_lsp" },
+          { name = "buffer" },
+          { name = "path" },
+        },
+      }
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- add `hrsh7th/nvim-cmp` completion plugin and common sources
- map `<Tab>` to confirm selections
- document that auto completion is powered by `nvim-cmp`

## Testing
- `stylua init.lua lua`

------
https://chatgpt.com/codex/tasks/task_e_687dd5213d24832b9c17087d135ce467