### PR TITLE
Enable spelling in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a personal Neovim setup focused on writing Markdown and
 - LSP management via mason and mason-lspconfig
 - Formatting and linting through null-ls
 - Render Markdown preview in the terminal
+- Automatic spell checking for Markdown and Vimwiki files (`en_us` by default)
 
 ## Installation
 Clone the repo into your Neovim config directory:

--- a/lua/spreadneck/autocmds.lua
+++ b/lua/spreadneck/autocmds.lua
@@ -5,5 +5,7 @@ vim.api.nvim_create_autocmd("FileType", {
   pattern = { "markdown", "vimwiki" },
   callback = function(args)
     vim.treesitter.start(args.buf)
+    vim.api.nvim_buf_set_option(args.buf, "spell", true)
+    vim.api.nvim_buf_set_option(args.buf, "spelllang", "en_us")
   end,
 })


### PR DESCRIPTION
## Summary
- enable spell checking in Markdown and Vimwiki buffers
- mention new spelling feature in README

## Testing
- `stylua init.lua lua/spreadneck/autocmds.lua`


------
https://chatgpt.com/codex/tasks/task_e_687dd5202b90832b818fea8302547e72