### PR TITLE
Add nvim-cmp integration with LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a personal Neovim setup focused on writing Markdown and
 - Treesitter support for Markdown and Vimwiki
 - Git integration with gitsigns and vim-fugitive
 - LSP management via mason and mason-lspconfig
+- Auto completion powered by nvim-cmp
 - Formatting and linting through null-ls
 - Render Markdown preview in the terminal
 

--- a/lua/spreadneck/plugins/cmp.lua
+++ b/lua/spreadneck/plugins/cmp.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    "hrsh7th/nvim-cmp",
+    dependencies = {
+      "hrsh7th/cmp-buffer",
+      "hrsh7th/cmp-path",
+      "hrsh7th/cmp-nvim-lsp",
+    },
+    config = function()
+      local cmp = require "cmp"
+      cmp.setup {
+        mapping = cmp.mapping.preset.insert {
+          ["<Tab>"] = cmp.mapping.confirm { select = true },
+          ["<C-Space>"] = cmp.mapping.complete {},
+          ["<C-n>"] = cmp.mapping.select_next_item(),
+          ["<C-p>"] = cmp.mapping.select_prev_item(),
+        },
+        sources = {
+          { name = "nvim_lsp" },
+          { name = "buffer" },
+          { name = "path" },
+        },
+      }
+    end,
+  },
+}

--- a/lua/spreadneck/plugins/mason.lua
+++ b/lua/spreadneck/plugins/mason.lua
@@ -29,15 +29,17 @@ return {
       mason_lspconfig.setup(opts)
 
       local lspconfig = require "lspconfig"
+      local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
       if mason_lspconfig.setup_handlers then
         -- Newer versions expose setup_handlers
         mason_lspconfig.setup_handlers {
           function(server)
-            lspconfig[server].setup {}
+            lspconfig[server].setup { capabilities = capabilities }
           end,
           ["lua_ls"] = function()
             lspconfig.lua_ls.setup {
+              capabilities = capabilities,
               settings = {
                 Lua = { diagnostics = { globals = { "vim" } } },
               },
@@ -49,12 +51,13 @@ return {
         for _, server in ipairs(mason_lspconfig.get_installed_servers()) do
           if server == "lua_ls" then
             lspconfig.lua_ls.setup {
+              capabilities = capabilities,
               settings = {
                 Lua = { diagnostics = { globals = { "vim" } } },
               },
             }
           else
-            lspconfig[server].setup {}
+            lspconfig[server].setup { capabilities = capabilities }
           end
         end
       end


### PR DESCRIPTION
## Summary
- enable completion plugin `nvim-cmp` with buffer, path and LSP sources
- mention nvim-cmp in README feature list
- pass cmp's capabilities to all LSP servers

## Testing
- `stylua init.lua lua`


------
https://chatgpt.com/codex/tasks/task_e_687dd5213d24832b9c17087d135ce467