### PR TITLE
Add mini tabline with which-key buffer navigation

### DIFF
--- a/lua/spreadneck/maps.lua
+++ b/lua/spreadneck/maps.lua
@@ -18,3 +18,15 @@ map("i", "jk", "<ESC>")
 -- NeoTree
 map("n", "<leader>e", "<CMD>Neotree toggle<CR>")
 map("n", "<leader>r", "<CMD>Neotree focus<CR>")
+
+-- Buffers
+map("n", "<leader>bn", "<CMD>bnext<CR>")
+map("n", "<leader>bp", "<CMD>bprevious<CR>")
+local bufremove = function()
+    require("mini.bufremove").delete(0, false)
+end
+map("n", "<leader>bd", bufremove)
+
+for i = 1, 9 do
+    map("n", "<leader>b" .. i, "<CMD>buffer " .. i .. "<CR>")
+end

--- a/lua/spreadneck/plugins/bufferline.lua
+++ b/lua/spreadneck/plugins/bufferline.lua
@@ -1,0 +1,8 @@
+return {{
+    "echasnovski/mini.nvim",
+    version = false,
+    config = function()
+        require("mini.tabline").setup{}
+        require("mini.bufremove").setup{}
+    end,
+}}

--- a/lua/spreadneck/plugins/which-key.lua
+++ b/lua/spreadneck/plugins/which-key.lua
@@ -1,0 +1,18 @@
+return {{
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    config = function()
+        local wk = require("which-key")
+        wk.setup{}
+        local buffer_mappings = {
+            name = "+buffers",
+            n = {"<CMD>bnext<CR>", "Next buffer"},
+            p = {"<CMD>bprevious<CR>", "Prev buffer"},
+            d = {function() require("mini.bufremove").delete(0, false) end, "Delete buffer"},
+        }
+        for i = 1, 9 do
+            buffer_mappings[tostring(i)] = {"<CMD>buffer " .. i .. "<CR>", "Go to buffer " .. i}
+        end
+        wk.register({ b = buffer_mappings }, {prefix = "<leader>"})
+    end
+}}


### PR DESCRIPTION
## Summary
- add which-key plugin with buffer mappings
- use mini.tabline for bufferline functionality
- map `<leader>b{n,p,d}` for buffer navigation
- jump to buffers 1..9 via `<leader>b{1-9}`
- close buffers with mini.bufremove

## Testing
- `nvim --headless "+quit"`


------
https://chatgpt.com/codex/tasks/task_e_687e8fc33b6c832b971589d1db0a8c10