### PR TITLE
Add buffer navigation with which-key

### DIFF
--- a/lua/spreadneck/maps.lua
+++ b/lua/spreadneck/maps.lua
@@ -23,3 +23,16 @@ end, { desc = "Open mini.files at CWD" })
 
 -- Spelling
 vim.keymap.set("n", "<leader>ss", "z=", { desc = "Spelling suggestions" })
+
+-- Buffer navigation
+map("n", "<leader>bn", "<cmd>bnext<CR>", { desc = "Next buffer" })
+map("n", "<leader>bp", "<cmd>bprevious<CR>", { desc = "Previous buffer" })
+map("n", "<leader>bd", function()
+  require("mini.bufremove").delete(0, false)
+end, { desc = "Delete buffer" })
+
+for i = 1, 9 do
+  map("n", "<leader>b" .. i, function()
+    vim.cmd.buffer(i)
+  end, { desc = "Go to buffer " .. i })
+end

--- a/lua/spreadneck/plugins/mini.nvim.lua
+++ b/lua/spreadneck/plugins/mini.nvim.lua
@@ -9,6 +9,7 @@ return {
       require("mini.files").setup()
       require("mini.statusline").setup()
       require("mini.tabline").setup()
+      require("mini.bufremove").setup()
     end,
   },
 }

--- a/lua/spreadneck/plugins/which-key.lua
+++ b/lua/spreadneck/plugins/which-key.lua
@@ -1,19 +1,27 @@
-return { {
-  "folke/which-key.nvim",
-  event = "VeryLazy",
-  opts = {
-    -- your configuration comes here
-    -- or leave it empty to use the default settings
-    -- refer to the configuration section below
-  },
-  keys = {
-    {
-      "<leader>?",
-      function()
-        require("which-key").show({ global = false })
-      end,
-      desc = "Buffer Local Keymaps (which-key)",
+return {
+  {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    opts = {
+      -- your configuration comes here
+      -- or leave it empty to use the default settings
+      -- refer to the configuration section below
+    },
+    config = function(_, opts)
+      local wk = require "which-key"
+      wk.setup(opts)
+      wk.register {
+        ["<leader>b"] = { name = "+buffers" },
+      }
+    end,
+    keys = {
+      {
+        "<leader>?",
+        function()
+          require("which-key").show { global = false }
+        end,
+        desc = "Buffer Local Keymaps (which-key)",
+      },
     },
   },
-}
 }


### PR DESCRIPTION
## Summary
- add `mini.bufremove` setup
- add buffer navigation mappings under `<leader>b`
- register buffer group in which-key

## Testing
- `stylua init.lua lua`
- `nvim --headless +q`


------
https://chatgpt.com/codex/tasks/task_e_687e93eda230832bbd1e7d0c921af8d4